### PR TITLE
验证模式判断标准输入是否有数据

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -106,6 +106,9 @@ func ParseOptions() *Options {
 	if options.FileName != "" && !FileExists(options.FileName) {
 		gologger.Fatalf("文件:%s 不存在!\n", options.FileName)
 	}
+	if !options.Stdin && options.Verify && options.FileName == "" {
+		gologger.Fatalf("启用了 -verify 参数但传入域名为空!")
+	}
 	return options
 }
 func hasStdin() bool {


### PR DESCRIPTION
直接运行 `ksubdomain -verify` 时，程序会直接报错，因为 https://github.com/knownsec/ksubdomain/blob/24445eed4f/core/start.go#L32 未被初始化

错误堆栈如下

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x560878fe2096]

goroutine 1 [running]:
bufio.(*Reader).fill(0xc0003a3e60)
	bufio/bufio.go:101 +0xd6
bufio.(*Reader).ReadSlice(0xc0003a3e60, 0xa, 0x0, 0x54, 0x560878f0c410, 0xc0003a3b40, 0x560878f2f140)
	bufio/bufio.go:360 +0x3f
bufio.(*Reader).ReadLine(0xc0003a3e60, 0x560879828e00, 0xc0003ca060, 0xc0003ce000, 0xc00011a000, 0x560879833100, 0xc000018068)
	bufio/bufio.go:389 +0x36
ksubdomain/core.Start(0xc0001c8080)
	ksubdomain/core/start.go:134 +0x6c5
main.main()
	ksubdomain/cmd/ksubdomain.go:45 +0x38
```

本 PR 在校验输入参数的地方增加了一个判断，如果用户启用了 `-verify` 但 stdin 没有数据的话，输出一个提示，增强用户体验